### PR TITLE
fix: create log directory in entrypoint and forward args

### DIFF
--- a/config/start.sh
+++ b/config/start.sh
@@ -2,13 +2,9 @@
 
 # Please note that ET: Legacy is not compatible with PunkBuster enabled servers. ET: Legacy clients also cannot connect to servers running the ETPro mod.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-"${DIR}/etlded.x86_64" \
-    +set dedicated 2 \
-    +set vm_game 0 \
-    +set net_port 27960 \
-    +set sv_maxclients 20 \
-    +set fs_game legacy \
-    +set sv_punkbuster 0 \
-    +set fs_basepath "${DIR}" \
-    +set fs_homepath "${DIR}" \
-    +exec server.cfg
+
+# Ensure log directory exists under fs_homepath
+FS_HOMEPATH="${FS_HOMEPATH:-${DIR}}"
+mkdir -p "${FS_HOMEPATH}/legacy/log"
+
+exec "${DIR}/etlded.x86_64" "$@"


### PR DESCRIPTION
## Summary
- Create log directory under `FS_HOMEPATH` in entrypoint before starting the server
- Forward all arguments to `etlded` via `exec "$@"` so callers can override server settings

## Test plan
- [ ] Build image and verify log directory is created at startup
- [ ] Verify args passed via `docker run` are forwarded to `etlded`