### PR TITLE
fix: update GitHub Actions and stop duplicate Renovate Dashboard issues

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,6 @@
     "github>xUnholy/docker-etlegacy-server//.github/renovate/autoMerge.json5",
   ],
   "dependencyDashboardTitle": "Renovate Dashboard",
-  "dependencyDashboardAutoclose": true,
   "configWarningReuseIssue": true,
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "platformAutomerge": true,

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -61,20 +61,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate Renovate Configuration
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@c22827f47f4f4a5364bdba19e1fe36907ef1318e # v1.1.1
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@dcbd036807dcbefbc9201a1d581d0848d869c4e1 # v2.1.0
 
       - name: Generate Token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
           app-id: "${{ secrets.BOT_APP_ID }}"
           private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
 
       - name: Renovate
-        uses: renovatebot/github-action@8ac70de2fe55752c573155866e30735411e3b61c # v41.0.22
+        uses: renovatebot/github-action@8d75b92f43899d483728e9a8a7fd44238020f6e6 # v46.1.2
         with:
           configurationFile: .github/renovate.json5
           token: "x-access-token:${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
## Summary
- Update all GitHub Actions in `renovate.yaml` to latest versions (`actions/checkout` v6.0.2, `create-github-app-token` v2.2.1, `renovatebot/github-action` v46.1.2, `renovate-config-validator` v2.1.0)
- Remove `dependencyDashboardAutoclose` from Renovate config which caused a new dashboard issue every hourly run

## Test plan
- [ ] Verify Renovate workflow runs successfully after merge
- [ ] Confirm only a single dashboard issue is maintained going forward