### PR TITLE
fix: disable g_guidCheck to allow 2.60b/Steam clients

### DIFF
--- a/config/server.cfg
+++ b/config/server.cfg
@@ -12,7 +12,7 @@
 
 set g_log ""                                    // enable game logging if set. Name of game logging file - logs weapon changes, kills, connects etc.
 set g_logSync "1"                               // game logging options (0: buffered 1: synchronized)
-set g_guidCheck "1"                             // check guid validity of connecting players - "1" prevents 2.60b clients without PB from connecting
+set g_guidCheck "0"                             // check guid validity of connecting players - "1" prevents 2.60b clients without PB from connecting
 set g_protect "1"                               // mod side security options
 
 // OPTIMIZATIONS


### PR DESCRIPTION
## Summary
- Set `g_guidCheck` to `0` so vanilla 2.60b and Steam clients can connect
- The Steam release removed PunkBuster, so `g_guidCheck "1"` blocks all Steam players

## Test plan
- [ ] Verify Steam (2.60b) clients can connect to the server
- [ ] Verify ET Legacy clients can still connect