### PR TITLE
fix: rename server.cfg to default_server.cfg to avoid shadowing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM debian:bookworm
 WORKDIR /etlegacy
 
 COPY --from=builder --chown=1000:1000 /etlegacy /etlegacy
-COPY --chown=1000:1000 ./config/server.cfg /etlegacy/legacy/server.cfg
+COPY --chown=1000:1000 ./config/server.cfg /etlegacy/legacy/default_server.cfg
 COPY --chown=1000:1000 ./config/start.sh /etlegacy/start.sh
 
 USER 1000:1000


### PR DESCRIPTION
## Summary
- Rename `server.cfg` to `default_server.cfg` in the image at `/etlegacy/legacy/`
- When deploying in k8s, the ConfigMap mounts its own `server.cfg` at `fs_homepath` which shadows the image's copy entirely. Renaming lets the ConfigMap `server.cfg` `exec default_server.cfg` first, inheriting all base settings (gameplay, voting, LUA, omni-bot, class/weapon limits), then apply overrides

## Test plan
- [ ] Build image and verify `default_server.cfg` exists at `/etlegacy/legacy/`
- [ ] Verify k8s `server.cfg` can `exec default_server.cfg` successfully