### PR TITLE
Add .dockerignore to reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+README.md
+LICENSE
+docker-compose.yml
+*.md


### PR DESCRIPTION
Excludes unnecessary files (.git, .github, docs, docker-compose.yml) from the Docker build context. This speeds up builds and prevents accidental inclusion of non-essential files in the image.