### PR TITLE
Add Docker HEALTHCHECK for server process monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,7 @@ USER 1000:1000
 
 EXPOSE 27960/udp
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD test -d /proc/1/fd || exit 1
+
 ENTRYPOINT ["/etlegacy/start.sh"]


### PR DESCRIPTION
## Summary

- Adds a `HEALTHCHECK` instruction to the Dockerfile that verifies the etlded game server process (PID 1) is still running.
- Uses `test -d /proc/1/fd` to avoid requiring any additional packages in the final image.
- Configured with `--interval=30s`, `--timeout=5s`, and `--retries=3` for sensible defaults.

## Details

This enables Docker and orchestrators (Compose, Swarm, Kubernetes) to detect and automatically restart unhealthy containers. Since etlded runs as PID 1 via `exec` in the entrypoint script, checking `/proc/1/fd` reliably confirms the process is alive without installing `procps` or any other tooling.

## Test plan

- [ ] Build the image locally and verify `docker inspect <container> | grep -A5 Health` shows the healthcheck config.
- [ ] Run the container and confirm `docker ps` shows `(healthy)` after the initial startup period.
- [ ] Verify the healthcheck fails and the container is marked `(unhealthy)` if the entrypoint process is killed.

Generated with [Claude Code](https://claude.com/claude-code)