### PR TITLE
Fix registry inconsistency: push to GHCR instead of DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -29,18 +32,19 @@ jobs:
           install: true
           version: latest
 
-      - name: Login to DockerHub
+      - name: Login to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Add Image Metadata"
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: xunholy/enemy-territory
+          images: ghcr.io/xunholy/enemy-territory
           flavor: |
             latest=auto
           tags: |


### PR DESCRIPTION
## Summary

The `docker-compose.yml` already references `ghcr.io/xunholy/enemy-territory:latest` but the CI workflow was pushing to DockerHub. This aligns CI to push to GHCR using the built-in `GITHUB_TOKEN`, removing the need for separate DockerHub credentials.

- Rename login step from "Login to DockerHub" to "Login to GHCR"
- Switch `docker/login-action` credentials to use `registry: ghcr.io`, `github.actor`, and `secrets.GITHUB_TOKEN`
- Update the metadata step `images` value from `xunholy/enemy-territory` to `ghcr.io/xunholy/enemy-territory`
- Add `permissions: contents: read, packages: write` at the job level so the workflow token can push packages to GHCR

## Test plan

- [ ] Verify the workflow runs successfully on a push to `main`
- [ ] Confirm the image is published to `ghcr.io/xunholy/enemy-territory` and not DockerHub
- [ ] Confirm `docker-compose.yml` pulls the image correctly from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)