### PR TITLE
Add resource limits and security hardening to Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,12 @@ services:
     volumes:
       - ./config/server.cfg:/etlegacy/legacy/server.cfg
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '2.0'
+        reservations:
+          memory: 256M


### PR DESCRIPTION
## Summary

- Adds `no-new-privileges` security option to prevent privilege escalation inside the container
- Sets memory limit (512M) and CPU limit (2 cores) to prevent runaway resource consumption
- Sets memory reservation (256M) as a soft limit for scheduling

These are sensible defaults for an ET:Legacy dedicated server. Adjust limits based on player count and bot configuration.

## Test plan

- [ ] Verify `docker compose up` starts the server successfully with the new configuration
- [ ] Confirm the container cannot escalate privileges (e.g. `docker exec` as non-root user cannot gain root)
- [ ] Monitor memory and CPU usage under load to validate limits are appropriate for your server setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)