### PR TITLE
Add persistent volumes for logs and game data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,10 @@ services:
       - "27960:27960/udp"
     volumes:
       - ./config/server.cfg:/etlegacy/legacy/server.cfg
+      - etlegacy-logs:/etlegacy/legacy/log
+      - etlegacy-etmain:/etlegacy/etmain
     restart: unless-stopped
+
+volumes:
+  etlegacy-logs:
+  etlegacy-etmain:


### PR DESCRIPTION
Adds named Docker volumes for persistent runtime data:

- `etlegacy-logs` — persists server logs across container restarts (`legacy/log/`)
- `etlegacy-etmain` — persists custom downloaded maps and game data (`etmain/`)

Without these volumes, all runtime state (logs, downloaded maps, WolfAdmin data) is lost when the container is removed. Named volumes ensure data survives `docker compose down && docker compose up` cycles.