### PR TITLE
Add environment variable config templating support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,15 @@ RUN rm -f /etlegacy/etl.x86_64 /etlegacy/etl_bot.x86_64.sh \
 # Stage 2: Copy only necessary files to a minimal final image
 FROM debian:bookworm
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gettext-base && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /etlegacy
 
 COPY --from=builder --chown=1000:1000 /etlegacy /etlegacy
 COPY --chown=1000:1000 ./config/server.cfg /etlegacy/legacy/server.cfg
+COPY --chown=1000:1000 ./config/server.cfg.template /etlegacy/legacy/server.cfg.template
 COPY --chown=1000:1000 ./config/start.sh /etlegacy/start.sh
 
 USER 1000:1000

--- a/config/server.cfg.template
+++ b/config/server.cfg.template
@@ -1,0 +1,157 @@
+// ET: Legacy legacy mod sample config file. Make this file your own.
+
+// see https://github.com/etlegacy/etlegacy/wiki
+//     https://github.com/etlegacy/etlegacy/wiki/Set-up-Features
+//     https://github.com/etlegacy/etlegacy/wiki/List-of-Cvars
+//
+// Lua server administration suite provided by WolfAdmin
+// see https://dev.timosmit.com/wolfadmin/
+
+set sv_hostname "${SERVER_NAME:-ETLegacy Server}"
+set sv_maxclients "${MAX_CLIENTS:-20}"
+set g_password "${SERVER_PASSWORD:-}"
+set rconPassword "${RCON_PASSWORD:-}"
+
+// LOGGING & PROTECTION
+
+set g_log ""                                    // enable game logging if set. Name of game logging file - logs weapon changes, kills, connects etc.
+set g_logSync "1"                               // game logging options (0: buffered 1: synchronized)
+set g_guidCheck "0"                             // check guid validity of connecting players - "1" prevents 2.60b clients without PB from connecting
+set g_protect "1"                               // mod side security options
+
+// OPTIMIZATIONS
+
+set g_antiwarp "1"
+set g_maxWarp "4"
+
+// LEVEL UP CUSTOMIZATION
+
+set skill_soldier "20 50 90 140"
+set skill_medic "20 50 90 140"
+set skill_fieldops "20 50 90 140"
+set skill_engineer "20 50 90 140"
+set skill_covertops "20 50 90 140"
+set skill_battlesense "20 50 90 140"
+set skill_lightweapons "20 50 90 140"
+
+// CLASS LIMITING
+
+set team_maxSoldiers "-1"
+set team_maxMedics "-1"
+set team_maxEngineers "-1"
+set team_maxFieldops "-1"
+set team_maxCovertops "-1"
+
+// WEAPONS LIMITING
+
+set team_maxMortars "-1"
+set team_maxFlamers "-1"
+set team_maxMachineguns "-1"
+set team_maxRockets "-1"
+set team_maxRiflegrenades "-1"
+set team_maxAirstrikes "0.0"
+set team_maxArtillery "0.0"
+set team_maxLandmines "10"
+set team_riflegrenades "1"
+
+// GAMEPLAY
+
+set g_dropAmmo "2"                              // number of ammo packs dropped on fieldop death
+set g_dropHealth "2"                            // number of health packs dropped on medic death
+set g_shove "60"                                // shove distance
+set g_misc "0"                                  // misc options
+set g_countryflags "1"                          // toggle player flags
+set g_skillRating "2"                           // toggle skill rating system
+set g_prestige "1"                              // toggle prestige system
+
+// MISC
+
+set g_heavyWeaponRestriction "100"              // heavy weapon restriction (% of team that have Heavy Weapons)
+set g_antilag "1"                               // enable antilag
+set g_altStopwatchMode "0"                      // enable ABAB stopwatch team format
+set g_autofireteams "1"                         // automatically put team players into FireTeams
+set g_complaintlimit "6"                        // number of complaints needed to kick a player
+set g_disableComplaints "1"                     // disable complaints for airstrike, artillery, mortar and landmines team kills
+set g_ipcomplaintlimit "3"                      // number of different player complaints to kick a player
+set g_fastres "0"                               // toggle instantly active player after medic revive
+set g_friendlyFire "1"                          // toggle Friendly Fire
+set g_minGameClients "8"                        // minimum number of players needed to start a match
+set g_maxlives "0"                              // number of respawns a player has
+set g_alliedmaxlives "0"                        // number of lives available to the allied team
+set g_axismaxlives "0"                          // number of lives available to the axis team
+set g_teamforcebalance "1"                      // stop players from joining a team with more players
+set g_noTeamSwitching "0"                       // disallow players from joining a team with more players
+set g_voiceChatsAllowed "5"                     // number of VSays a player can say in 30 seconds
+set g_doWarmup "0"                              // players have a warm up period
+set g_warmup "10"                               // warm up time (in seconds)
+set g_intermissionTime "30"                     // intermission time (in seconds)
+set g_intermissionReadyPercent "60"             // % of players "Ready" to start next map
+set g_spectatorInactivity "0"                   // duration of spectator inactivity before auto-kick
+set match_latejoin "1"                          // allow players to join a match that has already begun
+set match_minplayers "4"                        // minimum number of players needed to start a match
+set match_mutespecs "0"                         // mute spectators
+set match_readypercent "100"                    // % of players "Ready" to start match
+set match_timeoutcount "0"                      // number of timeout allowed
+set match_warmupDamage "1"                      // toggle warmup damage (0: Off 1: Enemy Only 2: Everybody)
+set team_maxplayers "0"                         // maximum number of players that can join each team
+set team_nocontrols "1"                         // disallow players from having team control
+set pmove_fixed "0"                             // frame rate independent physics
+set pmove_msec "8"                              // emulated frame rate dependent physics (8: 125 FPS emulated)
+set g_mapScriptDirectory "mapscripts"           // mapscripts directory
+set g_campaignFile ""                           // campaign file
+set g_customConfig ""                           // custom config file
+
+// LMS ONLY SETTINGS
+
+set g_lms_teamForceBalance "1"                  // force Team Balance
+set g_lms_roundlimit "3"                        // number of Rounds per Match
+set g_lms_matchlimit "2"                        // number of Matches
+set g_lms_lockTeams "0"                         // lock teams during a round
+set g_lms_followTeamOnly "1"                    // players can only spectate teammates
+
+// VOTING
+
+set g_allowVote "1"                             // enable voting system
+set vote_limit "5"                              // number of votes allowed in a map
+set vote_percent "50"                           // % of "Yes" votes required to pass
+set vote_allow_config "1"                       // allow config changing by vote
+set vote_allow_gametype "1"                     // allow gametype changing by vote
+set vote_allow_kick "1"                         // allow kick by vote
+set vote_allow_map "1"                          // allow map changing by vote
+set vote_allow_maprestart "1"                   // allow match restart by vote
+set vote_allow_matchreset "1"                   // allow match reset by vote
+set vote_allow_mutespecs "1"                    // allow spectators mute by vote
+set vote_allow_nextmap "1"                      // allow changing to next map by vote
+set vote_allow_referee "0"                      // allow getting referee status by vote
+set vote_allow_shuffleteams "1"                 // allow team shuffling by vote
+set vote_allow_shuffleteams_norestart "1"       // allow team shuffling no restart by vote
+set vote_allow_swapteams "1"                    // allow team swapping by vote
+set vote_allow_friendlyfire "1"                 // allow friendly fire toggling by vote
+set vote_allow_timelimit "0"                    // allow map time limit changing by vote
+set vote_allow_warmupdamage "1"                 // allow warmup damage toggling by vote
+set vote_allow_antilag "1"                      // allow toggling antilag setting by vote
+set vote_allow_balancedteams "1"                // allow toggling balanced teams by vote
+set vote_allow_muting "1"                       // allow player muting by vote
+set vote_allow_surrender "1"                    // allow surrender by vote
+set vote_allow_restartcampaign "1"              // allow restart campaign by vote
+set vote_allow_nextcampaign "1"                 // allow next campaign by vote
+set vote_allow_poll "1"                         // allow free polls by vote
+set vote_allow_cointoss "1"                     // allow coin toss by vote
+
+// MAP VOTING
+
+//set g_excludedMaps "railgun"
+//set g_maxMapsVotedFor "6"
+//set g_mapVoteFlags "0"
+//set g_minMapAge "3"
+
+// LUA
+
+set lua_modules "luascripts/wolfadmin/main.lua"
+set lua_allowedModules ""
+
+// OMNI-BOT
+
+set omnibot_enable "1"
+set omnibot_path "./legacy/omni-bot"
+set omnibot_flags "0"

--- a/config/start.sh
+++ b/config/start.sh
@@ -7,4 +7,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 FS_HOMEPATH="${FS_HOMEPATH:-${DIR}}"
 mkdir -p "${FS_HOMEPATH}/legacy/log"
 
+# Apply environment variable substitution to config template if it exists
+if [ -f "${DIR}/legacy/server.cfg.template" ]; then
+    envsubst < "${DIR}/legacy/server.cfg.template" > "${DIR}/legacy/server.cfg"
+fi
+
 exec "${DIR}/etlded.x86_64" "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,9 @@ services:
       - "27960:27960/udp"
     volumes:
       - ./config/server.cfg:/etlegacy/legacy/server.cfg
-      - etlegacy-logs:/etlegacy/legacy/log
-      - etlegacy-etmain:/etlegacy/etmain
+    # environment:
+    #   - SERVER_NAME=My ETLegacy Server
+    #   - RCON_PASSWORD=changeme
+    #   - SERVER_PASSWORD=
+    #   - MAX_CLIENTS=20
     restart: unless-stopped
-
-volumes:
-  etlegacy-logs:
-  etlegacy-etmain:


### PR DESCRIPTION
Adds support for runtime configuration via environment variables using `envsubst` templating.

**How it works:**
- A `server.cfg.template` file contains ET:Legacy config with `${ENV_VAR}` placeholders
- On container startup, `start.sh` runs `envsubst` to generate `server.cfg` from the template
- If no template exists (e.g., when bind-mounting a static config), the behavior is unchanged

**Supported environment variables:**
| Variable | Default | Description |
|----------|---------|-------------|
| `SERVER_NAME` | `ETLegacy Server` | Server name shown in browser |
| `RCON_PASSWORD` | *(empty)* | Remote console password |
| `SERVER_PASSWORD` | *(empty)* | Password to join the server |
| `MAX_CLIENTS` | `20` | Maximum connected players |

This follows the 12-factor app methodology, making the same image usable across environments without rebuilding or mounting config files.