### PR TITLE
Fix Renovate dashboard issue spam

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,7 @@
     "github>xUnholy/docker-etlegacy-server//.github/renovate/autoMerge.json5",
   ],
   "dependencyDashboardTitle": "Renovate Dashboard",
+  "dependencyDashboardLabels": ["renovate"],
   "configWarningReuseIssue": true,
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "platformAutomerge": true,

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,8 +52,6 @@ env:
   RENOVATE_AUTODISCOVER: true
   RENOVATE_AUTODISCOVER_FILTER: "${{ github.repository }}"
   WORKFLOW_RENOVATE_VERSION: "${{ inputs.version || 'latest' }}"
-  RENOVATE_USERNAME: "${{ secrets.BOT_USERNAME }}[bot]"
-  RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 
 jobs:
   renovate:


### PR DESCRIPTION
## Summary
- Remove `RENOVATE_USERNAME` and `RENOVATE_GIT_AUTHOR` env overrides that caused identity mismatch when searching for existing dashboard issues
- Renovate auto-detects its identity from the GitHub App token — the manual overrides caused `Retrieved 0 issues` on every run, creating a new dashboard issue hourly
- Add `dependencyDashboardLabels` for reliable issue lookup